### PR TITLE
[0.1.2.3] Elevacion de version 0.1.2.2 -> 0.1.2.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,27 @@
-[0.1.2.2]
+# **[0.1.2.3]**
+
+- Se agrega comandos para hacer chat global cuando ya haya iniciado el UHC
+> `/global` [alias] `/g` `/G` `/GLOBAL` *\<args\>* Menssaje a mandar chat global
+> - En caso de que se mande el mensaje sin el comando el mensaje se manda únicamente al equipo
+> 
+> ![imgage](https://user-images.githubusercontent.com/29431799/201827943-74313e95-923b-471c-8b3e-bbfec3a496df.jpg)
+
+- Se configura para que los ghast no dropeen la lagrima de ghast y ahora esta debe de ser crafteada con el siguiente 
+crafteo:
+>![image](https://user-images.githubusercontent.com/29431799/201828833-2e89e7e3-dedb-4a56-9fdf-18bbc1bf40f7.jpg)
+
+- Se configura crafteo de manzana encantada con cabeza de jugador
+> ![image](https://user-images.githubusercontent.com/29431799/201829045-53045870-e2d9-4651-919e-2e26fdf0b9ca.jpg)
+
+- Se configura crafteo y funcionamiento de las brújulas para buscar enemigos
+> ![image](https://user-images.githubusercontent.com/29431799/201829358-95640ec4-940f-4493-b4c0-751f3d234e7d.jpg)
+> - Estas siempre apuntan al jugador **Enemigo** más cercano; funciona en ambas manos,
+> en caso de que se cambie por brújulas normales apuntarán a 0 0
+> 
+> ![image](https://user-images.githubusercontent.com/29431799/201830068-5202eae9-0d76-4fcd-be67-4c6680286377.jpg)
+> ![image](https://user-images.githubusercontent.com/29431799/201830157-2993e722-0718-4106-86b8-e478855f8444.jpg)
+
+# **[0.1.2.2]**
 
 - Se agrega comando y clase para el control de la regeneración natural
 > `/regeneration` Obtener estado de la regeneración\
@@ -14,10 +37,10 @@
 > ![image](https://user-images.githubusercontent.com/29431799/201584588-6920d8f4-bea1-487a-81ab-ddcb0c13b01f.png)
 - Se agrega comando para añadir jugadores a los equipos
 >`/teams add_player <Team> <Jugador>`
-- Se configura mecanica de revivido en base a estructura
-  ![image](https://user-images.githubusercontent.com/29431799/201585579-3e97dfaf-6e20-4f55-a0c7-e28cdb2626e0.png)
+- Se configura mecanica de revivido basándonos en estructura
+> ![image](https://user-images.githubusercontent.com/29431799/201585579-3e97dfaf-6e20-4f55-a0c7-e28cdb2626e0.png)
 
-[0.1.2.1]
+# **[0.1.2.1]**
 
 - Se añade funcion para cuando alguien muere
 > Al morir el jugador suelta una cabeza con el numero de identificacion unico del mismo

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>co.com.okaeri</groupId>
     <artifactId>FunkyUHC</artifactId>
-    <version>0.1.2.2</version>
+    <version>0.1.2.3</version>
     <packaging>jar</packaging>
 
     <name>FunkyUHC</name>

--- a/src/main/java/co/com/okaeri/funkyuhc/FunkyUHC.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/FunkyUHC.java
@@ -1,16 +1,15 @@
 package co.com.okaeri.funkyuhc;
 
 import co.com.okaeri.funkyuhc.commands.*;
+import co.com.okaeri.funkyuhc.commands.Regeneration;
 import co.com.okaeri.funkyuhc.commands.TabCompleter.mapSizeTab;
 import co.com.okaeri.funkyuhc.commands.TabCompleter.teamsTab;
 import co.com.okaeri.funkyuhc.controller.GetTime;
 import co.com.okaeri.funkyuhc.database.Database;
 import co.com.okaeri.funkyuhc.database.Heads;
 import co.com.okaeri.funkyuhc.database.SQLite;
-import co.com.okaeri.funkyuhc.player.BlockDestroyListener;
-import co.com.okaeri.funkyuhc.player.BlockPlaceListener;
-import co.com.okaeri.funkyuhc.player.DeathListener;
-import co.com.okaeri.funkyuhc.player.ScoreManager;
+import co.com.okaeri.funkyuhc.items.ItemManager;
+import co.com.okaeri.funkyuhc.player.*;
 import co.com.okaeri.funkyuhc.util.Colors;
 import fr.mrmicky.fastboard.FastBoard;
 import org.apache.commons.lang.StringUtils;
@@ -58,6 +57,7 @@ public final class FunkyUHC extends JavaPlugin {
     public Map<Player, FastBoard> boards = new HashMap<>();
     public Colors colors = new Colors();
     public ScoreManager manager;
+    public ItemManager itemsManager;
 
     public GetTime timer = new GetTime();
 
@@ -102,8 +102,24 @@ public final class FunkyUHC extends JavaPlugin {
         // agregar registro de destrucción de bloques
         this.pm.registerEvents(new BlockDestroyListener(this), this);
 
+        // agregar registro de chat
+        this.pm.registerEvents(new ChatListener(this), this);
+
+        // Cargar manager de muertes de Ghast
+        this.pm.registerEvents(new GhastDrop(this), this);
+
+        // Cargar registro de crafteos
+        // this.pm.registerEvents(new ItemCraftEvent(this), this);
+
+        // Cargar registro de movimientos de jugador
+        this.pm.registerEvents(new PlayerMove(this), this);
+
         // Cargar teams almacenados en la base de datos
         this.teams = db.getTeams();
+
+        // Cargar crafteos custom
+        this.itemsManager = new ItemManager(this);
+        itemsManager.LoadCustomCrafts();
 
         // Cargar manager de scoreboards
         this.manager = new ScoreManager(this);
@@ -179,6 +195,8 @@ public final class FunkyUHC extends JavaPlugin {
         this.getCommand("uhc").setExecutor(new UhcController(this));
 
         this.getCommand("score").setExecutor(new ScoreBoard(this));
+
+        this.getCommand("global").setExecutor(new GlobalMessage(this));
     }
 
 }

--- a/src/main/java/co/com/okaeri/funkyuhc/commands/GlobalMessage.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/commands/GlobalMessage.java
@@ -1,0 +1,47 @@
+package co.com.okaeri.funkyuhc.commands;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GlobalMessage implements CommandExecutor{
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private FunkyUHC plugin;
+
+    public GlobalMessage(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        if (plugin.UhcStarted){
+
+            String subFix;
+
+            if (sender instanceof Player){
+                String team = plugin.TeamDB.getTeam(sender.getName());
+
+                subFix = plugin.TeamDB.getTeamColor(team) + "<" + sender.getName() + "> [" + team + "]" + plugin.colors.reset;
+            } else {
+                subFix = plugin.colors.underline + plugin.colors.dark_red + "[Server]" + plugin.colors.reset;
+            }
+
+            //noinspection ReassignedVariable
+            String message = "";
+
+            for (String arg: args){
+                message = message.concat(" " + arg);
+            }
+
+            plugin.getServer().broadcastMessage(plugin.colors.bold + subFix + message);
+
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/co/com/okaeri/funkyuhc/database/Teams.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/database/Teams.java
@@ -19,7 +19,7 @@ public class Teams {
         this.plugin = plugin;
     }
 
-    //TODO: agregar funciones para editar nombre, cambiar color, creacion y modificacion compañeros de equipo
+    //TODO: agregar funciones para editar nombre, cambiar color y modificacion compañeros de equipo
 
     @SuppressWarnings("UnusedReturnValue")
     public boolean Create(String name, String capitan, String color) {
@@ -50,7 +50,6 @@ public class Teams {
 
                 if (team.contains(capitan)){
                     plugin.print("Solo se puede ser capitán de un equipo a la vez");
-                    // TODO No deja crear mas de un equipo, hacer consulta directamenten en bd
                     return false;
                 }
             }
@@ -324,6 +323,40 @@ public class Teams {
             String sql = "UPDATE players SET kills = ? WHERE player = ?";
             PreparedStatement pstmt = plugin.db.connection.prepareStatement(sql);
             pstmt.setInt(1, kills);
+            pstmt.setString(2, player);
+
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public boolean getDeath(String player){
+        try {
+            Statement statment = plugin.db.statement();
+
+            return statment.executeQuery("SELECT * FROM players WHERE player =\"" +
+                    player + "\";").getBoolean("death");
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+
+    public void setDeath(String player, Boolean death){
+        try {
+            String sql = "UPDATE players SET kills = ? WHERE player = ?";
+            PreparedStatement pstmt = plugin.db.connection.prepareStatement(sql);
+
+            if (death){
+                pstmt.setInt(1, 0);
+            } else {
+                pstmt.setInt(1, 1);
+            }
+
             pstmt.setString(2, player);
 
             pstmt.executeUpdate();

--- a/src/main/java/co/com/okaeri/funkyuhc/items/ItemManager.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/items/ItemManager.java
@@ -1,0 +1,78 @@
+package co.com.okaeri.funkyuhc.items;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Collections;
+
+public class ItemManager {
+
+    @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
+    private FunkyUHC plugin;
+
+    public ItemManager(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    public void LoadCustomCrafts(){
+        ghastTearRecipe();
+        enchantedGapple();
+        enemyCompass();
+    }
+
+    private void ghastTearRecipe(){
+        ShapedRecipe sr = new ShapedRecipe(Material.GHAST_TEAR.getKey(), new ItemStack(Material.GHAST_TEAR));
+        sr.shape(" S ",
+                 "SGS",
+                 " S ");
+        sr.setIngredient('S', Material.GLISTERING_MELON_SLICE);
+        sr.setIngredient('G', Material.GOLD_BLOCK);
+        this.plugin.getServer().addRecipe(sr);
+    }
+
+    private void enchantedGapple(){
+        ShapedRecipe sr = new ShapedRecipe(Material.ENCHANTED_GOLDEN_APPLE.getKey(),
+                new ItemStack(Material.ENCHANTED_GOLDEN_APPLE));
+
+        sr.shape("GGG",
+                 "GHG",
+                 "GGG");
+
+        sr.setIngredient('G', Material.GOLD_BLOCK);
+        sr.setIngredient('H', Material.PLAYER_HEAD);
+
+        this.plugin.getServer().addRecipe(sr);
+
+    }
+
+    private void enemyCompass(){
+
+        ItemStack item = new ItemStack(Material.COMPASS);
+        ItemMeta meta = item.getItemMeta();
+
+        assert meta != null;
+        meta.setDisplayName(plugin.colors.bold + plugin.colors.yellow + "Brújula de enemigos" + plugin.colors.reset);
+        meta.setLore(Collections.singletonList("Brújula para buscar jugadores cercanos"));
+
+        item.setItemMeta(meta);
+
+        //noinspection ConstantConditions
+        ShapedRecipe sr = new ShapedRecipe(NamespacedKey.fromString("uhc:compass"), item);
+
+        sr.shape(" H ",
+                 "DCD",
+                 " G ");
+
+        sr.setIngredient('H', Material.PLAYER_HEAD);
+        sr.setIngredient('D', Material.DIAMOND);
+        sr.setIngredient('C', Material.COMPASS);
+        sr.setIngredient('G', Material.GOLD_BLOCK);
+
+        this.plugin.getServer().addRecipe(sr);
+    }
+
+}

--- a/src/main/java/co/com/okaeri/funkyuhc/player/BlockPlaceListener.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/BlockPlaceListener.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 public class BlockPlaceListener implements Listener {
@@ -36,7 +37,6 @@ public class BlockPlaceListener implements Listener {
 
             //noinspection unused
             ItemMeta itemmeta = event.getItemInHand().getItemMeta();
-            // TODO: guardar lore en la base de datos y borrar en caso de que se quite
             plugin.heads.setHead(item, player, block);
 
         } else if (item.getType() == Material.FLINT_AND_STEEL || item.getType() == Material.FIRE_CHARGE) {
@@ -50,23 +50,23 @@ public class BlockPlaceListener implements Listener {
 
                     if (start.getRelative(1,-1,0).getType().equals(Material.GOLD_BLOCK)){
                         structure.add(start.getRelative(1,-1,0));
-                        rightOrient(start, structure);
+                        rightOrient(start, structure, player);
                     } else if (start.getRelative(-1, -1,0).getType().equals(Material.GOLD_BLOCK)) {
                         structure.add(start.getRelative(-1, -1,0));
-                        leftOrient(start, structure);
+                        leftOrient(start, structure, player);
                     } else if (start.getRelative(0,-1, 1).getType().equals(Material.GOLD_BLOCK)){
                         structure.add(start.getRelative(0,-1, 1));
-                        frontOrient(start, structure);
+                        frontOrient(start, structure, player);
                     } else if (start.getRelative(0,-1, -1).getType().equals(Material.GOLD_BLOCK)) {
                         structure.add(start.getRelative(0,-1, -1));
-                        backOrient(start, structure);
+                        backOrient(start, structure, player);
                     }
                 }
         }
     }
 
     @SuppressWarnings("ReassignedVariable")
-    private void rightOrient(Block block, List<Block> structure){
+    private void rightOrient(Block block, List<Block> structure, Player placer){
 
         // Verificar primero si del lado opuesto ya hay fuego prendio para evitar procesos innecesarios
 
@@ -101,7 +101,7 @@ public class BlockPlaceListener implements Listener {
                         plugin.print("uuid: " + uuid);
                         plugin.print("name: " + name);
 
-                        revive(uuid, c_block, structure);
+                        revive(uuid, c_block, structure, placer);
 
                     }
                 }
@@ -111,7 +111,7 @@ public class BlockPlaceListener implements Listener {
     }
 
     @SuppressWarnings("ReassignedVariable")
-    private void leftOrient(Block block, List<Block> structure){
+    private void leftOrient(Block block, List<Block> structure, Player placer){
 
         // Verificar primero si del lado opuesto ya hay fuego prendio para evitar procesos innecesarios
 
@@ -146,7 +146,7 @@ public class BlockPlaceListener implements Listener {
                         plugin.print("uuid: " + uuid);
                         plugin.print("name: " + name);
 
-                        revive(uuid, c_block, structure);
+                        revive(uuid, c_block, structure, placer);
 
                     }
                 }
@@ -156,7 +156,7 @@ public class BlockPlaceListener implements Listener {
     }
 
     @SuppressWarnings("ReassignedVariable")
-    private void backOrient(Block block, List<Block> structure){
+    private void backOrient(Block block, List<Block> structure, Player placer){
 
         // Verificar primero si del lado opuesto ya hay fuego prendio para evitar procesos innecesarios
 
@@ -191,7 +191,7 @@ public class BlockPlaceListener implements Listener {
                         plugin.print("uuid: " + uuid);
                         plugin.print("name: " + name);
 
-                        revive(uuid, c_block, structure);
+                        revive(uuid, c_block, structure, placer);
 
                     }
                 }
@@ -201,7 +201,7 @@ public class BlockPlaceListener implements Listener {
     }
 
     @SuppressWarnings("ReassignedVariable")
-    private void frontOrient(Block block, List<Block> structure){
+    private void frontOrient(Block block, List<Block> structure, Player placer){
 
         // Verificar primero si del lado opuesto ya hay fuego prendio para evitar procesos innecesarios
 
@@ -236,7 +236,7 @@ public class BlockPlaceListener implements Listener {
                         plugin.print("uuid: " + uuid);
                         plugin.print("name: " + name);
 
-                        revive(uuid, c_block, structure);
+                        revive(uuid, c_block, structure, placer);
 
                     }
                 }
@@ -245,21 +245,22 @@ public class BlockPlaceListener implements Listener {
         }
     }
 
-    public void revive(UUID player, Block head, List<Block> structure){
+    public void revive(UUID player, Block head, List<Block> structure, Player placer){
 
         Player p = plugin.getServer().getPlayer(player);
 
-        // TODO: agregar el que ya no esta vivo en la bd
-
         assert p != null;
-        p.teleport(head.getLocation());
-        // TODO: generar aviso de que se ha revivido a unjugador a todos los jugadores y animación de revivido
+        if(Objects.equals(plugin.TeamDB.getTeam(p.getName()), plugin.TeamDB.getTeam(placer.getName()))) {
+            plugin.TeamDB.setDeath(p.getName(), false);
+            p.teleport(head.getLocation());
+            // TODO: generar aviso de que se ha revivido a unjugador a todos los jugadores y animación de revivido
 
-        for (Block block: structure){
-            block.setType(Material.AIR);
-        }
+            for (Block block : structure) {
+                block.setType(Material.AIR);
+            }
 
-        p.setGameMode(GameMode.SURVIVAL);
+            p.setGameMode(GameMode.SURVIVAL);
+        } // TODO agregar aviso de que no se puede revivir a alguien de otro equipo
 
     }
 }

--- a/src/main/java/co/com/okaeri/funkyuhc/player/ChatListener.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/ChatListener.java
@@ -1,0 +1,56 @@
+package co.com.okaeri.funkyuhc.player;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class ChatListener implements Listener {
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private FunkyUHC plugin;
+
+    public ChatListener(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void chat(AsyncPlayerChatEvent event) {
+
+        if (plugin.UhcStarted && (event.getPlayer().getGameMode() != GameMode.SPECTATOR)) {
+            Player p = event.getPlayer();
+            String message = event.getMessage();
+            event.setCancelled(true);
+
+            String team = plugin.TeamDB.getTeam(p.getName());
+            String capitan = plugin.TeamDB.getTeamCapitan(team);
+
+            try {
+
+                if(!(p.getName().equals(capitan))) {
+                    //noinspection ConstantConditions
+                    plugin.getServer().getPlayer(capitan).sendMessage("<" + p.getName() + "> " + message);
+                }
+
+            } catch (NullPointerException ignored){}
+
+            //noinspection ConstantConditions
+            plugin.print(p.getPlayer().getName() + " m: " + message);
+
+            for (String team_players: plugin.TeamDB.getTeamPlayers(team)){
+                Player team_player = plugin.getServer().getPlayer(team_players);
+
+                try {
+                    if (!(team_players.equals(p.getName()))) {
+                        //noinspection ConstantConditions
+                        team_player.sendMessage("<" + p.getName() + "> " + message);
+                    }
+                } catch (NullPointerException ignored){}
+
+            }
+
+        }
+    }
+}

--- a/src/main/java/co/com/okaeri/funkyuhc/player/DeathListener.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/DeathListener.java
@@ -21,24 +21,24 @@ public class DeathListener implements Listener{
 
     @EventHandler
     public void Muertes(PlayerDeathEvent e){
-        Player p = e.getEntity();
+        if (plugin.UhcStarted) {
+            Player p = e.getEntity();
 
-        Head h = new Head();
+            Head h = new Head();
 
-        ItemStack drop = h.getPlayerHead(p);
-        p.getWorld().dropItem(p.getLocation(), drop);
+            ItemStack drop = h.getPlayerHead(p);
+            p.getWorld().dropItem(p.getLocation(), drop);
 
-        plugin.print(e.getEntity() + " death " + e.getEntity().getLastDamageCause() + e.getEntity().getKiller());
-        plugin.print("death id" + e.getEntity().getUniqueId());
+            plugin.print(e.getEntity() + " death " + e.getEntity().getLastDamageCause() + e.getEntity().getKiller());
+            plugin.print("death id" + e.getEntity().getUniqueId());
 
-        if (e.getEntity().getKiller() != null){
-            plugin.TeamDB.addKill(e.getEntity().getKiller().getName());
+            if (e.getEntity().getKiller() != null) {
+                plugin.TeamDB.addKill(e.getEntity().getKiller().getName());
+            }
+
+            plugin.TeamDB.setDeath(p.getName(), true);
+
+            p.setGameMode(GameMode.SPECTATOR);
         }
-
-        p.setGameMode(GameMode.SPECTATOR);
-
     }
-
-
-
 }

--- a/src/main/java/co/com/okaeri/funkyuhc/player/GhastDrop.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/GhastDrop.java
@@ -1,0 +1,25 @@
+package co.com.okaeri.funkyuhc.player;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+public class GhastDrop implements Listener{
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private FunkyUHC plugin;
+
+    public GhastDrop(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void DisableGhastDrops(EntityDeathEvent event){
+        if(plugin.UhcStarted && event.getEntity().getType().equals(EntityType.GHAST)){
+            event.getDrops().removeIf(drop -> drop.getType().equals(Material.GHAST_TEAR));
+        }
+    }
+}

--- a/src/main/java/co/com/okaeri/funkyuhc/player/ItemCraftEvent.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/ItemCraftEvent.java
@@ -1,0 +1,44 @@
+package co.com.okaeri.funkyuhc.player;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+
+public class ItemCraftEvent implements Listener {
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private FunkyUHC plugin;
+
+    public ItemCraftEvent(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onItemCraft(PrepareItemCraftEvent event){
+        if ((event.getRecipe() instanceof ShapedRecipe) && event.getRecipe().getResult().getType().equals(Material.ENCHANTED_GOLDEN_APPLE)){
+
+            for (ItemStack s: event.getInventory().getMatrix()){
+                if(s.getType().equals(Material.PLAYER_HEAD)){
+
+                    ItemMeta meta = s.getItemMeta();
+                    //noinspection ConstantConditions
+                    String headName = meta.getLore().get(0).replace("Cabeza de: ", "");
+                    meta.setLore(Arrays.asList("Manzana creada con la cabeza de", headName));
+                    ItemStack itemStack = event.getInventory().getResult();
+                    //noinspection ConstantConditions
+                    itemStack.setItemMeta(meta);
+                    event.getInventory().setResult(itemStack);
+                }
+            }
+            plugin.print(event.getInventory().getResult() + "");
+
+        }
+    }
+}

--- a/src/main/java/co/com/okaeri/funkyuhc/player/PlayerMove.java
+++ b/src/main/java/co/com/okaeri/funkyuhc/player/PlayerMove.java
@@ -1,0 +1,104 @@
+package co.com.okaeri.funkyuhc.player;
+
+import co.com.okaeri.funkyuhc.FunkyUHC;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class PlayerMove implements Listener {
+
+    @SuppressWarnings("FieldMayBeFinal")
+    private FunkyUHC plugin;
+
+    public PlayerMove(FunkyUHC plugin){
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event){
+
+        ItemStack main_hand = event.getPlayer().getInventory().getItemInMainHand();
+        ItemStack off_hand = event.getPlayer().getInventory().getItemInOffHand();
+        Location default_location = new Location(event.getPlayer().getWorld(), 0.0d, 0.0d, 0.0d);
+
+        if(main_hand.getType().equals(Material.COMPASS)){
+            try {
+                //noinspection ConstantConditions
+                if (main_hand.getItemMeta().getLore().get(0).equals("Brújula para buscar jugadores cercanos")){
+                    String team = plugin.TeamDB.getTeam(event.getPlayer().getName());
+
+                    List<String> team_players = plugin.TeamDB.getTeamPlayers(team);
+                    team_players.add(plugin.TeamDB.getTeamCapitan(team));
+
+                    Map<Double, Player> locations = new HashMap<>();
+
+                    for (Player p: plugin.getServer().getOnlinePlayers()){
+
+                        if (!team_players.contains(p.getName()) && !p.isDead() && p.getGameMode().equals(GameMode.SURVIVAL)) {
+                            locations.put(p.getLocation().distance(event.getPlayer().getLocation()), p);
+                        }
+                    }
+
+                    Map.Entry<Double, Player> min = null;
+                    for (Map.Entry<Double, Player> entry : locations.entrySet()) {
+                        if (min == null || min.getKey() > entry.getKey()) {
+                            min = entry;
+                        }
+                    }
+
+                    assert min != null;
+                    event.getPlayer().setCompassTarget(min.getValue().getLocation());
+
+                } else {
+                    event.getPlayer().setCompassTarget(default_location);
+                }
+            }catch (NullPointerException e){
+                event.getPlayer().setCompassTarget(default_location);
+            }
+
+        } else if (off_hand.getType().equals(Material.COMPASS)) {
+
+            try {
+                //noinspection ConstantConditions
+                if (main_hand.getItemMeta().getLore().get(0).equals("Brújula para buscar jugadores cercanos")){
+                    String team = plugin.TeamDB.getTeam(event.getPlayer().getName());
+
+                    List<String> team_players = plugin.TeamDB.getTeamPlayers(team);
+                    team_players.add(plugin.TeamDB.getTeamCapitan(team));
+
+                    Map<Double, Player> locations = new HashMap<>();
+
+                    for (Player p: plugin.getServer().getOnlinePlayers()){
+
+                        if (!team_players.contains(p.getName()) && !p.isDead() && p.getGameMode().equals(GameMode.SURVIVAL)) {
+                            locations.put(p.getLocation().distance(event.getPlayer().getLocation()), p);
+                        }
+                    }
+
+                    Map.Entry<Double, Player> min = null;
+                    for (Map.Entry<Double, Player> entry : locations.entrySet()) {
+                        if (min == null || min.getKey() > entry.getKey()) {
+                            min = entry;
+                        }
+                    }
+
+                    assert min != null;
+                    event.getPlayer().setCompassTarget(min.getValue().getLocation());
+
+                } else {
+                    event.getPlayer().setCompassTarget(default_location);
+                }
+            }catch (NullPointerException e){
+                event.getPlayer().setCompassTarget(default_location);
+            }
+
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -25,3 +25,10 @@ commands:
 
   score:
     description: Comando de scoreboard
+
+  global:
+    description: Enviar un chat a todos los equipos
+    aliases:
+      - g
+      - G
+      - GLOBAL


### PR DESCRIPTION
- Se agrega comandos para hacer chat global cuando ya haya iniciado el UHC
> `/global` [alias] `/g` `/G` `/GLOBAL` *\<args\>* Menssaje a mandar chat global
> - En caso de que se mande el mensaje sin el comando el mensaje se manda únicamente al equipo
> 
> ![imgage](https://user-images.githubusercontent.com/29431799/201827943-74313e95-923b-471c-8b3e-bbfec3a496df.jpg)

- Se configura para que los ghast no dropeen la lagrima de ghast y ahora esta debe de ser crafteada con el siguiente 
crafteo:
>![image](https://user-images.githubusercontent.com/29431799/201828833-2e89e7e3-dedb-4a56-9fdf-18bbc1bf40f7.jpg)

- Se configura crafteo de manzana encantada con cabeza de jugador
> ![image](https://user-images.githubusercontent.com/29431799/201829045-53045870-e2d9-4651-919e-2e26fdf0b9ca.jpg)

- Se configura crafteo y funcionamiento de las brújulas para buscar enemigos
> ![image](https://user-images.githubusercontent.com/29431799/201829358-95640ec4-940f-4493-b4c0-751f3d234e7d.jpg)
> - Estas siempre apuntan al jugador **Enemigo** más cercano; funciona en ambas manos,
> en caso de que se cambie por brújulas normales apuntarán a 0 0
> 
> ![image](https://user-images.githubusercontent.com/29431799/201830068-5202eae9-0d76-4fcd-be67-4c6680286377.jpg)
> ![image](https://user-images.githubusercontent.com/29431799/201830157-2993e722-0718-4106-86b8-e478855f8444.jpg)
